### PR TITLE
Rename TipInfo to Info

### DIFF
--- a/docs/projects/initialize.mdx
+++ b/docs/projects/initialize.mdx
@@ -16,7 +16,7 @@ If you're interested in custom projects or models, please reach out [here](https
 | `config_url` | string (optional) | URL to config JSON |
 | `config` | object (optional) | Config JSON |
 
-<TipInfo>Either a `config` or a `config_url` must be specified</TipInfo>
+<Info>Either a `config` or a `config_url` must be specified</Info>
 
 ### Request
 
@@ -30,7 +30,7 @@ curl https://api.sievedata.com/v1/init_project \
     "config_url": "YOUR_CONFIG_URL"
   }'
 ```
-<TipInfo>A project name needs to be specified on every API request having to do with project data.</TipInfo>
+<Info>A project name needs to be specified on every API request having to do with project data.</Info>
 
 ### Sample Response
 


### PR DESCRIPTION
Mintlify is renaming TipInfo and TipWarning to Info and Warning.

This PR renames your callouts automatically.