### PR TITLE
fix: change Audio to File type in transcribe code

### DIFF
--- a/docs/guide/examples/audio-transcription.mdx
+++ b/docs/guide/examples/audio-transcription.mdx
@@ -40,7 +40,7 @@ import sieve
 
 
 def transcribe_audio():
-    target_audio = sieve.Audio(
+    target_audio = sieve.File(
         url="https://storage.googleapis.com/sieve-public-data/assets/dub.m4a")
 
     transcriber = sieve.function.get("sieve/speech_transcriber")


### PR DESCRIPTION
`sieve/speech_transcriber` should accept Audio but doesn't currently due to serialization issues.

https://sievehq.slack.com/archives/C02LZ06P5AB/p1705088412135769 https://sievehq.slack.com/archives/C05Q64XF7FD/p1705083789057749